### PR TITLE
Extend support for string based media breakpoints

### DIFF
--- a/lib/Picture.js
+++ b/lib/Picture.js
@@ -3,6 +3,9 @@ const React = require('react')
 const h = React.createElement
 
 const Picture = React.forwardRef(function Picture({ src, sizes, breakpoints, ...imgProps }, ref) {
+
+  console.log({src, sizes, breakpoints})
+
   if (!src) {
     return null
   }

--- a/lib/Picture.js
+++ b/lib/Picture.js
@@ -4,8 +4,6 @@ const h = React.createElement
 
 const Picture = React.forwardRef(function Picture({ src, sizes, breakpoints, ...imgProps }, ref) {
 
-  console.log({src, sizes, breakpoints})
-
   if (!src) {
     return null
   }

--- a/lib/Picture.js
+++ b/lib/Picture.js
@@ -49,7 +49,7 @@ const Picture = React.forwardRef(function Picture({ src, sizes, breakpoints, ...
   return h(
     'picture',
     {},
-    flattendSrc.map(({ img, sizes, breakpoints, maxWidth }, i) =>
+    flattendSrc.map(({ img, sizes, breakpoints, maxWidth, media }, i) =>
       h(
         React.Fragment,
         { key: i },
@@ -59,6 +59,7 @@ const Picture = React.forwardRef(function Picture({ src, sizes, breakpoints, ...
             type: 'image/webp',
             srcSet: img.webpSrcSet,
             sizes: makeSizes(img, sizes, breakpoints),
+            media,
             ...(maxWidth ? { media: `(max-width: ${maxWidth}px)` } : {}),
           }),
         img.srcSet &&
@@ -90,7 +91,7 @@ function flattenSrc(src, sizes, breakpoints) {
       img: src[i],
       sizes: sizes[i],
       breakpoints: src.length === 1 ? breakpoints : [],
-      maxWidth: i === src.length - 1 ? null : breakpoints[i],
+      media: i === src.length - 1 ? null : `(max-width: ${breakpoints[i]}px)`,
     })
   }
 

--- a/lib/Picture.js
+++ b/lib/Picture.js
@@ -49,7 +49,7 @@ const Picture = React.forwardRef(function Picture({ src, sizes, breakpoints, ...
   return h(
     'picture',
     {},
-    flattendSrc.map(({ img, sizes, breakpoints, maxWidth, media }, i) =>
+    flattendSrc.map(({ img, sizes, breakpoints, media }, i) =>
       h(
         React.Fragment,
         { key: i },
@@ -60,7 +60,6 @@ const Picture = React.forwardRef(function Picture({ src, sizes, breakpoints, ...
             srcSet: img.webpSrcSet,
             sizes: makeSizes(img, sizes, breakpoints),
             media,
-            ...(maxWidth ? { media: `(max-width: ${maxWidth}px)` } : {}),
           }),
         img.srcSet &&
           img.srcSet.length > 0 &&
@@ -68,7 +67,7 @@ const Picture = React.forwardRef(function Picture({ src, sizes, breakpoints, ...
             type: img.type,
             srcSet: img.srcSet,
             sizes: makeSizes(img, sizes, breakpoints),
-            ...(maxWidth ? { media: `(max-width: ${maxWidth}px)` } : {}),
+            media,
           }),
       ),
     ),
@@ -87,11 +86,13 @@ function flattenSrc(src, sizes, breakpoints) {
       continue
     }
 
+    const breakpoint = typeof breakpoints[i] === 'number' ? `(max-width: ${breakpoints[i]}px)` : breakpoints[i]
+
     result.push({
       img: src[i],
       sizes: sizes[i],
       breakpoints: src.length === 1 ? breakpoints : [],
-      media: i === src.length - 1 ? null : `(max-width: ${breakpoints[i]}px)`,
+      media: i === src.length - 1 ? null : breakpoint,
     })
   }
 


### PR DESCRIPTION
- now also supports defining your own breakpoints as media quires as a string of any complexity. 
- Non-breaking change that also works the previous way with px maxWidths.
eg. `breakpoints={['(orientation: landscape)']}`